### PR TITLE
chore: Bump edition and packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tailscale"
 description = "A set of application-level primitives for Tailscale."
 version = "0.1.1"
 authors = ["Morgan Gallant <morgan@xor.dev>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 repository = "https://github.com/xortechnologies/tailscale-rs"
 license = "MIT"
@@ -11,5 +11,6 @@ keywords = ["tailscale", "ipn", "intranet"]
 categories = ["network-programming"]
 
 [dependencies]
-pnet = "0.26.0"
-ipnetwork = "0.16.0"
+pnet = "0.31.0"
+ipnetwork = "0.20.0"
+pnet_datalink = "0.31.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ extern crate ipnetwork;
 extern crate pnet;
 
 use ipnetwork::IpNetwork;
-use pnet::datalink;
 use std::net::IpAddr;
 
 fn maybe_tailscale(s: &str) -> bool {
@@ -23,13 +22,12 @@ fn maybe_tailscale(s: &str) -> bool {
 /// let iface = tailscale::interface().expect("no tailscale interface found");
 /// ```
 pub fn interface() -> Option<IpAddr> {
-    let ifaces = datalink::interfaces();
+    let ifaces = pnet_datalink::interfaces();
     let netmask: IpNetwork = "100.64.0.0/10".parse().unwrap();
     ifaces
         .iter()
         .filter(|iface| maybe_tailscale(&iface.name))
-        .map(|iface| iface.ips.clone())
-        .flatten()
+        .flat_map(|iface| iface.ips.clone())
         .filter(|ipnet| ipnet.is_ipv4() && netmask.contains(ipnet.network()))
         .map(|ipnet| ipnet.ip())
         .next()


### PR DESCRIPTION
Just wanted to merge these changes upstream, in case they are useful to library consumers

What I've done:
- Bump edition and deps, added additional deps to the pnet library moving the datalink functionality to another lib. 
- Fixed lints